### PR TITLE
Enhance parser with typing, test suite, configurable debug and pyproject.toml fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Python Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install project and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .      
+          pip install pytest
+
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
-# Python virtual environment
+# Python virtual environments
 .venv/
 venv/
 
 # Packaging artifacts
 *.egg-info/
+
+# Bytecode cache
+__pycache__/
+*.py[cod]

--- a/parseidf.py
+++ b/parseidf.py
@@ -5,7 +5,8 @@
 # Sustainable Architecture and Building Technologies (Suat) at the Institute of
 # Technology in Architecture, ETH Zürich. See http://suat.arch.ethz.ch for
 # more information.
-'''
+
+"""
 parseidf.py
 
 
@@ -22,104 +23,166 @@ parses an idf file into a dictionary of lists in the following manner:
 
     also, all field values are strings, i.e. no interpretation of the values is
     made.
-'''
+"""
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, NoReturn
+
 import ply.lex as lex
 import ply.yacc as yacc
 
 # list of token names
-tokens = ('VALUE',
-          'COMMA',
-          'SEMICOLON')
+tokens = ("VALUE", "COMMA", "SEMICOLON")
 
 # regular expression rules for simple tokens
-t_COMMA = r'[ \t]*,[ \t]*'
-t_SEMICOLON = r'[ \t]*;[ \t]*'
+t_COMMA = r"[ \t]*,[ \t]*"
+t_SEMICOLON = r"[ \t]*;[ \t]*"
 
 
 # ignore comments, tracking line numbers at the same time
-def t_COMMENT(t):
-    r'[ \t\r\n]*!.*'
-    newlines = [n for n in t.value if n == '\n']
+def t_COMMENT(t) -> None:
+    r"[ \t\r\n]*!.*"
+    newlines = [n for n in t.value if n == "\n"]
     t.lineno += len(newlines)
     pass
     # No return value. Token discarded
 
 
 # Define a rule so we can track line numbers
-def t_newline(t):
-    r'[ \t]*(\r?\n)+'
+def t_newline(t) -> None:
+    r"[ \t]*(\r?\n)+"
     t.lexer.lineno += len(t.value)
 
 
-def t_VALUE(t):
-    r'[ \t]*([^!,;\n]|[*])+[ \t]*'
+def t_VALUE(t) -> Any:
+    r"[ \t]*([^!,;\n]|[*])+[ \t]*"
     return t
 
 
 # Error handling rule
-def t_error(t):
-    raise SyntaxError("Illegal character '%s' at line %d of input"
-                      % (t.value[0], t.lexer.lineno))
-    t.lexer.skip(1)
+def t_error(t) -> NoReturn:
+    raise SyntaxError(
+        f"Illegal character '{t.value[0]}' at line {t.lexer.lineno} of input"
+    )
 
 
 # define grammar of idf objects
-def p_idffile(p):
-    'idffile : idfobjectlist'
-    result = {}
+def p_idffile(p) -> None:
+    "idffile : idfobjectlist"
+    result: dict[str, list[list[str]]] = {}
     for idfobject in p[1]:
         name = idfobject[0]
         result.setdefault(name.upper(), []).append(idfobject)
     p[0] = result
 
 
-def p_idfobjectlist(p):
-    'idfobjectlist : idfobject'
+def p_idfobjectlist(p) -> None:
+    "idfobjectlist : idfobject"
     p[0] = [p[1]]
 
 
-def p_idfobjectlist_multiple(p):
-    'idfobjectlist : idfobject idfobjectlist'
+def p_idfobjectlist_multiple(p) -> None:
+    "idfobjectlist : idfobject idfobjectlist"
     p[0] = [p[1]] + p[2]
 
 
-def p_idfobject(p):
-    'idfobject : objectname SEMICOLON'
+def p_idfobject(p) -> None:
+    "idfobject : objectname SEMICOLON"
     p[0] = [p[1]]
 
 
-def p_idfobject_with_values(p):
-    'idfobject : objectname COMMA valuelist SEMICOLON'
+def p_idfobject_with_values(p) -> None:
+    "idfobject : objectname COMMA valuelist SEMICOLON"
     p[0] = [p[1]] + p[3]
 
 
-def p_objectname(p):
-    'objectname : VALUE'
+def p_objectname(p) -> None:
+    "objectname : VALUE"
     p[0] = p[1].strip()
 
 
-def p_valuelist(p):
-    'valuelist : VALUE'
+def p_valuelist(p) -> None:
+    "valuelist : VALUE"
     p[0] = [p[1].strip()]
 
 
-def p_valuelist_multiple(p):
-    'valuelist : VALUE COMMA valuelist'
+def p_valuelist_multiple(p) -> None:
+    "valuelist : VALUE COMMA valuelist"
     p[0] = [p[1].strip()] + p[3]
 
 
 # oh, and handle errors
-def p_error(p):
-    raise SyntaxError("Syntax error in input on line %d" % lex.lexer.lineno)
+def p_error(p) -> NoReturn:
+    if p:
+        raise SyntaxError(f"Syntax error at token '{p.value}' on line {p.lineno}")
+    else:
+        raise SyntaxError("Syntax error at EOF")
 
 
-def parse(input):
-    '''
-    parses a string with the contents of the idf file and returns the
-    dictionary representation.
-    '''
-    lexer = lex.lex(debug=False)
-    lexer.input(input)
-    parser = yacc.yacc()
-    result = parser.parse(debug=False)
+def parse(
+    idf_text: str, debug: bool = False, write_tables: bool = False
+) -> dict[str, list[list[str]]]:
+    """
+    Parses a string with the contents of the IDF file and returns a dictionary
+    mapping object types to lists of their field values.
+    """
+    lexer = lex.lex(debug=debug)
+    parser = yacc.yacc(debug=debug, write_tables=write_tables)
+    result = parser.parse(idf_text, lexer=lexer, debug=debug)
     return result
+
+
+def parse_file(
+    file_path: str | Path, debug: bool = False, write_tables: bool = False
+) -> dict[str, list[list[str]]]:
+    """
+    Reads an IDF file from a path and parses its contents.
+
+    :param file_path: The path to the IDF file.
+    :param debug: Passed to the parser/lexer's debug setting.
+    :param write_tables: Passed to the parser's write_tables setting.
+    :return: A dictionary mapping object types (str, uppercased) to lists
+        of their field value lists.
+    """
+    path = Path(file_path)
+    idf_text = path.read_text(encoding="utf-8")
+    return parse(idf_text, debug=debug, write_tables=write_tables)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description="Parse an EnergyPlus IDF file into a Python dictionary."
+    )
+    parser.add_argument("file", type=str, help="Path to the IDF file to be parsed.")
+    parser.add_argument("-d", "--debug", action="store_true")
+    parser.add_argument("-t", "--tables", action="store_true")
+
+    args = parser.parse_args()
+
+    try:
+        print(f"Parsing file: {args.file}...")
+        idf_data = parse_file(
+            file_path=args.file, debug=args.debug, write_tables=args.tables
+        )
+
+        print("\n--- Parse Successful ---")
+        print(f"Total objects parsed: {sum(len(v) for v in idf_data.values())}")
+        print("Object counts by type:")
+        for obj_type, obj_list in sorted(idf_data.items()):
+            print(f"  {obj_type:<30}: {len(obj_list)}")
+
+    except FileNotFoundError:
+        print(f"Error: File not found at {args.file}", file=sys.stderr)
+        sys.exit(1)
+
+    except SyntaxError as e:
+        print("\n--- PARSE FAILED ---", file=sys.stderr)
+        print(e, file=sys.stderr)
+        sys.exit(1)
+
+    except Exception as e:
+        print("\n--- UNEXPECTED ERROR ---", file=sys.stderr)
+        print(f"An unexpected error occurred: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,16 @@
 name = "parseidf"
 version = "1.0.0"
 description = "A module for parsing EnergyPlus IDF files"
-readme = "README.rst"
+readme = "README.md"
 license = { file = "LICENSE.txt" }
 authors = [
     { name = "Daren Thomas", email = "dthomas.ch@gmail.com" }
 ]
 keywords = ["simulation", "parsing", "energyplus"]
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"
 ]

--- a/tests/test_parseidf.py
+++ b/tests/test_parseidf.py
@@ -1,0 +1,75 @@
+import pytest
+
+from parseidf import parse
+
+
+def test_single_object_no_values():
+    idf = "Version;"
+    expected = {"VERSION": [["Version"]]}
+    assert parse(idf) == expected
+
+
+def test_single_object_with_values():
+    idf = "Material, Brick, 0.5, 0.8;"
+    expected = {"MATERIAL": [["Material", "Brick", "0.5", "0.8"]]}
+    assert parse(idf) == expected
+
+
+def test_multiple_objects_same_type():
+    idf = "Zone, LivingRoom, 20;\nZone, Kitchen, 15;"
+    expected = {
+        "ZONE": [
+            ["Zone", "LivingRoom", "20"],
+            ["Zone", "Kitchen", "15"],
+        ]
+    }
+    assert parse(idf) == expected
+
+
+def test_multiple_objects_different_types():
+    idf = "Building, MyHouse;\nZone, Bedroom, 12;"
+    expected = {
+        "BUILDING": [["Building", "MyHouse"]],
+        "ZONE": [["Zone", "Bedroom", "12"]],
+    }
+    assert parse(idf) == expected
+
+
+def test_comments_are_ignored():
+    idf = "! This is a comment\nMaterial, Wood, 0.3, 0.6; ! Another comment"
+    expected = {"MATERIAL": [["Material", "Wood", "0.3", "0.6"]]}
+    assert parse(idf) == expected
+
+
+def test_whitespace_and_newlines():
+    idf = "  Material ,  Wood , 0.3 , 0.6 ;\n\nZone , Bedroom , 12 ;"
+    expected = {
+        "MATERIAL": [["Material", "Wood", "0.3", "0.6"]],
+        "ZONE": [["Zone", "Bedroom", "12"]],
+    }
+    assert parse(idf) == expected
+
+
+def test_object_with_asterisk():
+    idf = "Schedule, *, *, *;"
+    expected = {"SCHEDULE": [["Schedule", "*", "*", "*"]]}
+    assert parse(idf) == expected
+
+
+@pytest.mark.parametrize(
+    "idf",
+    [
+        pytest.param("Material, Brick, 0.5, 0.8", id="missing_semicolon"),
+        pytest.param("Material, Brick, 0.5, 0.8; $", id="illegal_character"),
+        pytest.param("", id="empty_input"),
+    ],
+)
+def test_syntax_errors(idf):
+    with pytest.raises(SyntaxError):
+        parse(idf)
+
+
+def test_object_with_only_name_and_semicolon():
+    idf = "Building;"
+    expected = {"BUILDING": [["Building"]]}
+    assert parse(idf) == expected


### PR DESCRIPTION
PR introduces several improvements:
- adds full type annotations across the parser module for better clarity and tooling support  
- introduces a comprehensive unit test suite to validate parsing behavior and edge cases  
- refactors the `parse()` method to allow configurable `debug` and `write_tables` options  
- fixes an issue in `pyproject.toml` where the README was incorrectly set to `Readme.rst`; it now correctly points to `README.md`
- adds a command-line interface (CLI) for parsing IDF files directly via terminal  
- introduces a `parse_file()` helper for streamlined file-based parsing with error handling  
- enhances error reporting with clearer diagnostics for syntax, file and unexpected issues  
- prints object type counts and total parsed objects for quick validation after parsing  